### PR TITLE
MultiplePersistenceTransaction receiving any exceptions in first inner transaction prevent any further transactions being opened/closed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,13 @@
 			<version>2.4</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.easymock</groupId>
+			<artifactId>easymock</artifactId>
+			<version>3.4</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/premiumminds/persistence/MultiplePersistenceTransaction.java
+++ b/src/main/java/com/premiumminds/persistence/MultiplePersistenceTransaction.java
@@ -66,11 +66,13 @@ public class MultiplePersistenceTransaction implements PersistenceTransaction {
 						pt.setRollbackOnly();
 						rollback = true;
 					}
-				} catch (Exception e) { }
+				} catch (Exception e) {
+					log.warn("Failed to setRollbackOnly when ending transaction", e);
+				}
 				try {
 					pt.end();
 				} catch (Exception e) {
-					log.warn("Failed to end transaction at "+pt.getClass().getSimpleName()+": "+e.getMessage());
+					log.warn("Failed to end transaction", e);
 					caughtException = e;
 				}
 			}
@@ -95,7 +97,7 @@ public class MultiplePersistenceTransaction implements PersistenceTransaction {
 			try {
 				pt.setRollbackOnly();
 			} catch (Exception e) {
-				log.warn("Failed to mark transaction "+pt.getClass().getSimpleName()+" for rollback: "+e.getMessage());
+				log.warn("Failed to mark transaction for rollback", e);
 			}
 		}
 	}
@@ -106,7 +108,13 @@ public class MultiplePersistenceTransaction implements PersistenceTransaction {
 			try {
 				if(pt.isRollbackOnly()) return true;
 			} catch (Exception e) {
-				log.warn("Failed to determine rollback status for transaction "+pt.getClass().getSimpleName()+" for rollback: "+e.getMessage());
+				log.warn("Failed to determine rollback status for transaction, trying to set rollback", e);
+				try {
+					setRollbackOnly();
+				} catch (Exception ex) {
+					log.warn("Failed setRollbackOnly: should not happen", e);
+				}
+				return true;
 			}
 		}
 		return false;

--- a/src/main/java/com/premiumminds/persistence/MultiplePersistenceTransaction.java
+++ b/src/main/java/com/premiumminds/persistence/MultiplePersistenceTransaction.java
@@ -60,7 +60,11 @@ public class MultiplePersistenceTransaction implements PersistenceTransaction {
 		try {
 			boolean rollback = isRollbackOnly();
 			for(PersistenceTransaction pt : persistenceTransactions){
-				pt.end();
+				try {
+					pt.end();
+				} catch (Exception e) {
+					log.warn("Failed to end transaction at "+pt.getClass().getSimpleName()+": "+e.getMessage());
+				}
 			}
 			log.debug("Ending application transaction");
 			if(sync.get()!=null){
@@ -79,14 +83,22 @@ public class MultiplePersistenceTransaction implements PersistenceTransaction {
 	public void setRollbackOnly() {
 		log.debug("Marking application transaction for rollback");
 		for(PersistenceTransaction pt : persistenceTransactions){
-			pt.setRollbackOnly();
+			try {
+				pt.setRollbackOnly();
+			} catch (Exception e) {
+				log.warn("Failed to mark transaction "+pt.getClass().getSimpleName()+" for rollback: "+e.getMessage());
+			}
 		}
 	}
 
 	@Override
 	public boolean isRollbackOnly() {
 		for(PersistenceTransaction pt : persistenceTransactions){
-			if(pt.isRollbackOnly()) return true;
+			try {
+				if(pt.isRollbackOnly()) return true;
+			} catch (Exception e) {
+				log.warn("Failed to determine rollback status for transaction "+pt.getClass().getSimpleName()+" for rollback: "+e.getMessage());
+			}
 		}
 		return false;
 	}

--- a/src/test/java/com/premiumminds/persistence/MultiplePersistenceTransactionTest.java
+++ b/src/test/java/com/premiumminds/persistence/MultiplePersistenceTransactionTest.java
@@ -148,7 +148,6 @@ public class MultiplePersistenceTransactionTest extends EasyMockSupport {
 		EasyMock.expectLastCall().once();
 		
 		// set rollback
-		// start
 		t1.setRollbackOnly();
 		EasyMock.expectLastCall().once();
 		t2.setRollbackOnly();
@@ -187,7 +186,6 @@ public class MultiplePersistenceTransactionTest extends EasyMockSupport {
 		EasyMock.expectLastCall().once();
 		
 		// set rollback
-		// start
 		t1.setRollbackOnly();
 		EasyMock.expectLastCall().andThrow(new RuntimeException("some exception in setRollbackOnly"));
 		t2.setRollbackOnly();
@@ -266,6 +264,9 @@ public class MultiplePersistenceTransactionTest extends EasyMockSupport {
 		EasyMock.expect(t2.isRollbackOnly()).andReturn(false);
 		t1.end();
 		EasyMock.expectLastCall().andThrow(new RuntimeException("some exception in end transaction"));
+		// set rollback on second transaction since first ending failed
+		t2.setRollbackOnly();
+		EasyMock.expectLastCall().once();
 		t2.end();
 		
 		// start 2
@@ -275,7 +276,9 @@ public class MultiplePersistenceTransactionTest extends EasyMockSupport {
 		// end 2
 		EasyMock.expect(t1.isRollbackOnly()).andReturn(true);
 		t1.end();
+		EasyMock.expectLastCall().once();
 		t2.end();
+		EasyMock.expectLastCall().once();
 		
 		replayAll();
 		
@@ -287,7 +290,7 @@ public class MultiplePersistenceTransactionTest extends EasyMockSupport {
 		try {
 			tr.end();
 		} catch (Exception e) {
-			fail("should not throw exception anymore");
+			assertEquals("java.lang.RuntimeException: some exception in end transaction", e.getMessage());
 		}
 		try {
 			tr.start();

--- a/src/test/java/com/premiumminds/persistence/MultiplePersistenceTransactionTest.java
+++ b/src/test/java/com/premiumminds/persistence/MultiplePersistenceTransactionTest.java
@@ -1,0 +1,304 @@
+package com.premiumminds.persistence;
+
+import static org.junit.Assert.assertEquals;
+
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+import org.junit.Test;
+
+public class MultiplePersistenceTransactionTest extends EasyMockSupport {
+
+	@Test
+	public void testStarts() throws Exception {
+		
+		PersistenceTransaction t1 = createMock(PersistenceTransaction.class);
+		PersistenceTransaction t2 = createMock(PersistenceTransaction.class);
+		
+		// start
+		t1.start();
+		EasyMock.expectLastCall().once();
+		t2.start();
+		EasyMock.expectLastCall().once();
+				
+		replayAll();
+		
+		MultiplePersistenceTransaction tr = new MultiplePersistenceTransaction();
+		tr.add(t1);
+		tr.add(t2);
+		
+		tr.start();
+		
+		verifyAll();
+		
+	}
+
+	@Test
+	public void testStartsAndEnds() throws Exception {
+		
+		PersistenceTransaction t1 = createMock(PersistenceTransaction.class);
+		PersistenceTransaction t2 = createMock(PersistenceTransaction.class);
+		
+		// start
+		t1.start();
+		EasyMock.expectLastCall().once();
+		t2.start();
+		EasyMock.expectLastCall().once();
+		
+		// end
+		EasyMock.expect(t1.isRollbackOnly()).andReturn(false);
+		EasyMock.expect(t2.isRollbackOnly()).andReturn(false);
+		t1.end();
+		EasyMock.expectLastCall().once();
+		t2.end();
+		EasyMock.expectLastCall().once();
+		
+		replayAll();
+		
+		MultiplePersistenceTransaction tr = new MultiplePersistenceTransaction();
+		tr.add(t1);
+		tr.add(t2);
+		
+		tr.start();
+		tr.end();
+		
+		verifyAll();
+		
+	}
+	
+	@Test
+	public void testStartsAndEndsWithRollback() throws Exception {
+		
+		PersistenceTransaction t1 = createMock(PersistenceTransaction.class);
+		PersistenceTransaction t2 = createMock(PersistenceTransaction.class);
+		
+		// start
+		t1.start();
+		EasyMock.expectLastCall().once();
+		t2.start();
+		EasyMock.expectLastCall().once();
+		
+		// end
+		EasyMock.expect(t1.isRollbackOnly()).andReturn(false);
+		EasyMock.expect(t2.isRollbackOnly()).andReturn(true);
+		t1.end();
+		EasyMock.expectLastCall().once();
+		t2.end();
+		EasyMock.expectLastCall().once();
+		
+		replayAll();
+		
+		MultiplePersistenceTransaction tr = new MultiplePersistenceTransaction();
+		tr.add(t1);
+		tr.add(t2);
+		
+		tr.start();
+		tr.end();
+		
+		verifyAll();
+		
+	}
+
+	@Test
+	public void testStartsAndEndsWithRollbackException() throws Exception {
+		
+		PersistenceTransaction t1 = createMock(PersistenceTransaction.class);
+		PersistenceTransaction t2 = createMock(PersistenceTransaction.class);
+		
+		// start
+		t1.start();
+		EasyMock.expectLastCall().once();
+		t2.start();
+		EasyMock.expectLastCall().once();
+		
+		// end
+		EasyMock.expect(t1.isRollbackOnly()).andThrow(new RuntimeException("some exception in isRollbackOnly"));
+		EasyMock.expect(t2.isRollbackOnly()).andReturn(true);
+		t1.end();
+		EasyMock.expectLastCall().once();
+		t2.end();
+		EasyMock.expectLastCall().once();
+		
+		replayAll();
+		
+		MultiplePersistenceTransaction tr = new MultiplePersistenceTransaction();
+		tr.add(t1);
+		tr.add(t2);
+		
+		tr.start();
+		try {
+			tr.end();
+		} catch(Exception e) {
+			// bug - should still call isRollbackOnly for second transaction and not throw exception
+			assertEquals("some exception in isRollbackOnly", e.getMessage());
+		}
+		
+		verifyAll();
+	}
+	
+	@Test
+	public void testSetRollbackOnly() throws Exception {
+		
+		PersistenceTransaction t1 = createMock(PersistenceTransaction.class);
+		PersistenceTransaction t2 = createMock(PersistenceTransaction.class);
+		
+		// start
+		t1.start();
+		EasyMock.expectLastCall().once();
+		t2.start();
+		EasyMock.expectLastCall().once();
+		
+		// set rollback
+		// start
+		t1.setRollbackOnly();
+		EasyMock.expectLastCall().once();
+		t2.setRollbackOnly();
+		EasyMock.expectLastCall().once();
+		
+		// end
+		EasyMock.expect(t1.isRollbackOnly()).andReturn(true);
+		t1.end();
+		EasyMock.expectLastCall().once();
+		t2.end();
+		EasyMock.expectLastCall().once();
+		
+		replayAll();
+		
+		MultiplePersistenceTransaction tr = new MultiplePersistenceTransaction();
+		tr.add(t1);
+		tr.add(t2);
+		
+		tr.start();
+		tr.setRollbackOnly();
+		tr.end();
+		
+		verifyAll();
+	}
+	
+	@Test
+	public void testSetRollbackOnlyThrowsException() throws Exception {
+		
+		PersistenceTransaction t1 = createMock(PersistenceTransaction.class);
+		PersistenceTransaction t2 = createMock(PersistenceTransaction.class);
+		
+		// start
+		t1.start();
+		EasyMock.expectLastCall().once();
+		t2.start();
+		EasyMock.expectLastCall().once();
+		
+		// set rollback
+		// start
+		t1.setRollbackOnly();
+		EasyMock.expectLastCall().andThrow(new RuntimeException("some exception in setRollbackOnly"));
+		t2.setRollbackOnly();
+		EasyMock.expectLastCall().once();
+		
+		// end
+		EasyMock.expect(t1.isRollbackOnly()).andReturn(true);
+		t1.end();
+		EasyMock.expectLastCall().once();
+		t2.end();
+		EasyMock.expectLastCall().once();
+		
+		replayAll();
+		
+		MultiplePersistenceTransaction tr = new MultiplePersistenceTransaction();
+		tr.add(t1);
+		tr.add(t2);
+		
+		tr.start();
+		try {
+			tr.setRollbackOnly();
+		} catch (Exception e) {
+			// bug - should still call setRollbackOnly for second transaction
+			assertEquals("some exception in setRollbackOnly", e.getMessage());
+		}
+		tr.end();
+		
+		verifyAll();
+	}
+	
+	@Test
+	public void testMultipleStartsAndEnds() throws Exception {
+		
+		PersistenceTransaction t1 = createMock(PersistenceTransaction.class);
+		PersistenceTransaction t2 = createMock(PersistenceTransaction.class);
+		
+		// start
+		t1.start();
+		EasyMock.expectLastCall().times(2);
+		t2.start();
+		EasyMock.expectLastCall().times(2);
+		
+		// end
+		EasyMock.expect(t1.isRollbackOnly()).andReturn(false).times(2);
+		EasyMock.expect(t2.isRollbackOnly()).andReturn(true).times(2);
+		t1.end();
+		EasyMock.expectLastCall().times(2);
+		t2.end();
+		EasyMock.expectLastCall().times(2);
+		
+		replayAll();
+		
+		MultiplePersistenceTransaction tr = new MultiplePersistenceTransaction();
+		tr.add(t1);
+		tr.add(t2);
+		
+		tr.start();
+		tr.end();
+		tr.start();
+		tr.end();
+		
+		verifyAll();
+	}
+	
+	@Test
+	public void testMultipleStartsAndEndsThrowsException() throws Exception {
+		
+		PersistenceTransaction t1 = createMock(PersistenceTransaction.class);
+		PersistenceTransaction t2 = createMock(PersistenceTransaction.class);
+		
+		// start 1
+		t1.start();
+		t2.start();
+		
+		// end 1
+		EasyMock.expect(t1.isRollbackOnly()).andReturn(false);
+		EasyMock.expect(t2.isRollbackOnly()).andReturn(false);
+		t1.end();
+		EasyMock.expectLastCall().andThrow(new RuntimeException("some exception in end transaction"));
+		t2.end();
+		
+		// start 2
+		t1.start();
+		EasyMock.expectLastCall().andThrow(new RuntimeException("transaction already started"));
+		
+		// end 2
+		EasyMock.expect(t1.isRollbackOnly()).andReturn(true);
+		t1.end();
+		t2.end();
+		
+		replayAll();
+		
+		MultiplePersistenceTransaction tr = new MultiplePersistenceTransaction();
+		tr.add(t1);
+		tr.add(t2);
+		
+		tr.start();
+		try {
+			tr.end();
+		} catch (Exception e) {
+			// bug - should still call end for second transaction
+			assertEquals("some exception in end transaction", e.getMessage());
+		}
+		try {
+			tr.start();
+		} catch (Exception e) {
+			assertEquals("Aborting transaction start", e.getMessage());
+		}
+		tr.end();
+		
+		verifyAll();
+	}
+	
+}

--- a/src/test/java/com/premiumminds/persistence/MultiplePersistenceTransactionTest.java
+++ b/src/test/java/com/premiumminds/persistence/MultiplePersistenceTransactionTest.java
@@ -1,6 +1,7 @@
 package com.premiumminds.persistence;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
@@ -128,8 +129,7 @@ public class MultiplePersistenceTransactionTest extends EasyMockSupport {
 		try {
 			tr.end();
 		} catch(Exception e) {
-			// bug - should still call isRollbackOnly for second transaction and not throw exception
-			assertEquals("some exception in isRollbackOnly", e.getMessage());
+			fail("should not throw exception anymore");
 		}
 		
 		verifyAll();
@@ -210,8 +210,7 @@ public class MultiplePersistenceTransactionTest extends EasyMockSupport {
 		try {
 			tr.setRollbackOnly();
 		} catch (Exception e) {
-			// bug - should still call setRollbackOnly for second transaction
-			assertEquals("some exception in setRollbackOnly", e.getMessage());
+			fail("should not throw exception anymore");
 		}
 		tr.end();
 		
@@ -288,8 +287,7 @@ public class MultiplePersistenceTransactionTest extends EasyMockSupport {
 		try {
 			tr.end();
 		} catch (Exception e) {
-			// bug - should still call end for second transaction
-			assertEquals("some exception in end transaction", e.getMessage());
+			fail("should not throw exception anymore");
 		}
 		try {
 			tr.start();

--- a/src/test/java/com/premiumminds/persistence/MultiplePersistenceTransactionTest.java
+++ b/src/test/java/com/premiumminds/persistence/MultiplePersistenceTransactionTest.java
@@ -111,9 +111,15 @@ public class MultiplePersistenceTransactionTest extends EasyMockSupport {
 		t2.start();
 		EasyMock.expectLastCall().once();
 		
-		// end
 		EasyMock.expect(t1.isRollbackOnly()).andThrow(new RuntimeException("some exception in isRollbackOnly"));
-		EasyMock.expect(t2.isRollbackOnly()).andReturn(true);
+		
+		// previous exception requires set rollback afterwards
+		t1.setRollbackOnly();
+		EasyMock.expectLastCall().once();
+		t2.setRollbackOnly();
+		EasyMock.expectLastCall().once();
+		
+		// end
 		t1.end();
 		EasyMock.expectLastCall().once();
 		t2.end();


### PR DESCRIPTION
When MultiplePersistenceTransaction holds more than one PersistenceTransaction, say transaction A and B, and A fails for any reason (for example lost access to DB, timeouts, etc), there will be an exception thrown trying to close or setting rollback for A.

When that happens, there's never a call to close B so it's left open.

Next time when open transaction is called, A might succeed but B will always fail to start and throw an exception of its own, because the previous transaction was never closed.

Also when end is called again, isRollbackOnly will throw an exception in A because there is no active transaction for it, so it will never try to end the transaction still active in B and will never recover.

Added tests to confirm bug, and fix.