### PR TITLE
Adds Automatic-Module-Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,18 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>com.premiumminds.persistence</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
 
 			<plugin>
 				<groupId>com.mycila.maven-license-plugin</groupId>


### PR DESCRIPTION
Allows for easier migration to java modules by reserving the module name now and not rely on the jar filename.

fixes #132 